### PR TITLE
Fallback to project root deps.edn

### DIFF
--- a/test/lein_tools_deps/plugin_test.clj
+++ b/test/lein_tools_deps/plugin_test.clj
@@ -22,7 +22,9 @@
   (let [deps (sut/resolve-deps (absolute-base-path)
                (sut/canonicalise-dep-locs (absolute-base-path) ["test-cases/basic-deps.edn"]))]
     (is (map? deps))
-    (is (= ["src" "test"] (:source-paths deps)))))
+    (is (= [(.getAbsolutePath (io/file (absolute-base-path) "src"))
+            (.getAbsolutePath (io/file (absolute-base-path) "test"))]
+          (:source-paths deps)))))
 
 ;; TODO fix this test up properly.
 #_(deftest resolve-local-root-to-source-paths

--- a/test/lein_tools_deps/plugin_test.clj
+++ b/test/lein_tools_deps/plugin_test.clj
@@ -7,25 +7,25 @@
 ; of lein-tools-deps.plugin and at least we can know if it builds successfully.
 
 (deftest canonicalise-dep-refs-test
-  (let [canonicalised-files (sut/canonicalise-dep-locs [:system "test-cases/basic-deps.edn"])]
+  (let [canonicalised-files (sut/canonicalise-dep-locs "/users/foo/proj" [:system "test-cases/basic-deps.edn"])]
     (is (every? #(instance? java.io.File %) canonicalised-files))
     (is (every? #(.exists %) canonicalised-files))
     (is (= 2 (count canonicalised-files))
         ":system and supplied file == 2 files")))
 
 (deftest resolve-paths-to-source-paths
-  (let [deps (sut/resolve-deps (sut/canonicalise-dep-locs ["test-cases/basic-deps.edn"]))]
+  (let [deps (sut/resolve-deps (sut/canonicalise-dep-locs "/users/foo/proj" ["test-cases/basic-deps.edn"]))]
     (is (map? deps))
     (is (= ["src" "test"] (:source-paths deps)))))
 
 ;; TODO fix this test up properly.
 #_(deftest resolve-local-root-to-source-paths
-  (let [deps (sut/resolve-deps (sut/canonicalise-dep-locs ["test-cases/local-root-deps.edn"]))]
+  (let [deps (sut/resolve-deps (sut/canonicalise-dep-locs "/users/foo/proj" ["test-cases/local-root-deps.edn"]))]
     (is (map? deps))
     (is (= ["src" "test"] (:source-paths deps)))))
 
 (deftest resolve-deps-git-to-dependencies
-  (let [deps (sut/resolve-deps (sut/canonicalise-dep-locs ["test-cases/git-deps.edn"]))]
+  (let [deps (sut/resolve-deps (sut/canonicalise-dep-locs "/users/foo/proj" ["test-cases/git-deps.edn"]))]
     (is (map? deps))
     (let [dependencies (:dependencies deps)]
       (is (>= (count dependencies) 2))

--- a/test/lein_tools_deps/plugin_test.clj
+++ b/test/lein_tools_deps/plugin_test.clj
@@ -1,31 +1,39 @@
 (ns lein-tools-deps.plugin-test
   (:require [clojure.test :refer :all]
+            [clojure.java.io :as io]
             [lein-tools-deps.plugin :as sut]
-            [lein-tools-deps.plugin :as plugin]))
+            [lein-tools-deps.plugin :as plugin])
+  (:import (java.io File)))
 
 ; The mere presence of this file means that `lein test` will trigger a compilation
 ; of lein-tools-deps.plugin and at least we can know if it builds successfully.
 
+(defn absolute-base-path []
+  (.getAbsolutePath (io/file "")))
+
 (deftest canonicalise-dep-refs-test
-  (let [canonicalised-files (sut/canonicalise-dep-locs "/users/foo/proj" [:system "test-cases/basic-deps.edn"])]
+  (let [canonicalised-files (sut/canonicalise-dep-locs (absolute-base-path) [:system "test-cases/basic-deps.edn"])]
     (is (every? #(instance? java.io.File %) canonicalised-files))
     (is (every? #(.exists %) canonicalised-files))
     (is (= 2 (count canonicalised-files))
         ":system and supplied file == 2 files")))
 
 (deftest resolve-paths-to-source-paths
-  (let [deps (sut/resolve-deps (sut/canonicalise-dep-locs "/users/foo/proj" ["test-cases/basic-deps.edn"]))]
+  (let [deps (sut/resolve-deps (absolute-base-path)
+               (sut/canonicalise-dep-locs (absolute-base-path) ["test-cases/basic-deps.edn"]))]
     (is (map? deps))
     (is (= ["src" "test"] (:source-paths deps)))))
 
 ;; TODO fix this test up properly.
 #_(deftest resolve-local-root-to-source-paths
-  (let [deps (sut/resolve-deps (sut/canonicalise-dep-locs "/users/foo/proj" ["test-cases/local-root-deps.edn"]))]
+  (let [deps (sut/resolve-deps (absolute-base-path)
+               (sut/canonicalise-dep-locs (absolute-base-path) ["test-cases/local-root-deps.edn"]))]
     (is (map? deps))
     (is (= ["src" "test"] (:source-paths deps)))))
 
 (deftest resolve-deps-git-to-dependencies
-  (let [deps (sut/resolve-deps (sut/canonicalise-dep-locs "/users/foo/proj" ["test-cases/git-deps.edn"]))]
+  (let [deps (sut/resolve-deps (absolute-base-path)
+               (sut/canonicalise-dep-locs (absolute-base-path) ["test-cases/git-deps.edn"]))]
     (is (map? deps))
     (let [dependencies (:dependencies deps)]
       (is (>= (count dependencies) 2))
@@ -33,3 +41,44 @@
                     '[joda-time/joda-time "2.9.7"]}
                   dependencies)))))
 
+(deftest absolute-file-test
+  (let [base-path (absolute-base-path)]
+    (is (= (io/file base-path "deps.edn") (sut/absolute-file base-path "deps.edn")))
+    (is (= (io/file base-path "foo" "deps.edn") (sut/absolute-file base-path (str "foo" File/separator "deps.edn"))))
+    (let [abs-file (.getAbsoluteFile (io/file "some_dir" "deps.edn"))]
+      (is (= abs-file (sut/absolute-file base-path abs-file))))))
+
+(deftest absolute-local-root-coords-test
+  (let [base-path (absolute-base-path)]
+    (is (= {:local/root (.getAbsolutePath (io/file base-path "foo"))}
+          (sut/absolute-local-root-coords base-path {:local/root "foo"})))
+    (is (= {:local/root base-path}
+          (sut/absolute-local-root-coords base-path {:local/root base-path})))))
+
+(deftest absolute-coords-test
+  (let [base-path (absolute-base-path)]
+    (is (= {:mvn/version "1.0.0"} (sut/absolute-coords base-path {:mvn/version "1.0.0"})))
+    (is (= {:local/root (.getAbsolutePath (io/file base-path "foo"))}
+          (sut/absolute-coords base-path {:local/root "foo"})))))
+
+(deftest absolute-deps-map-test
+  (let [base-path (absolute-base-path)]
+    (is (= {'some-lib  {:mvn/version "1.0.0"}
+            'local-lib {:local/root (.getAbsolutePath (io/file base-path "foo"))}}
+          (sut/absolute-deps-map base-path {'some-lib  {:mvn/version "1.0.0"}
+                                            'local-lib {:local/root "foo"}})))))
+
+(deftest absolute-deps-test
+  (let [base-path (absolute-base-path)]
+    (is (= {:paths ["foo"]
+            :deps  {'some-lib  {:mvn/version "1.0.0"}
+                    'local-lib {:local/root (.getAbsolutePath (io/file base-path "foo"))}}
+            :aliases {:test {:extra-deps {'some-lib2 {:mvn/version "1.1.0"}
+                                          'local-lib2 {:local/root (.getAbsolutePath (io/file base-path "bar"))}}}
+                      :bar {:main-opts ["foo" "bar"]}}}
+          (sut/absolute-deps base-path {:paths   ["foo"]
+                                        :deps    {'some-lib  {:mvn/version "1.0.0"}
+                                                  'local-lib {:local/root "foo"}}
+                                        :aliases {:test {:extra-deps {'some-lib2  {:mvn/version "1.1.0"}
+                                                                      'local-lib2 {:local/root "bar"}}}
+                                                  :bar  {:main-opts ["foo" "bar"]}}})))))


### PR DESCRIPTION
Here is a potential patch to consider motivated by Cursive (or perhaps any tool that somehow manages to run the plugin without the current working directory being the same directory where the `project.clj` file is located).

> In Cursive's case, I verified that the working directory ends up being `/Applications/IntelliJ IDEA.app/Contents/bin` for me.

It essentially falls back to assuming `deps.edn` is in the same directory as `project.clj` if the user has specified `:project` in the `:tools/deps` vector but `project-deps` ends up being `nil`.

I tried another patch which involved doing `(with-sh-dir (:root project) ...` assuming that `tools.deps` was shelling out, but that didn't work out for some reason.

This patch only focuses on `project-deps`, but perhaps the general approach of inspecting `(:root project)` could also be used to ensure that relative deps in the `:tools/deps` vector are fully qualified relative to `(:root project)` (as opposed to relative to what the current working directory happens to be). But this patch doesn't go that far. Just wanted to send your way for initial feedback.