### PR TITLE
Bump lein-tools-deps version in example project

### DIFF
--- a/example/project.clj
+++ b/example/project.clj
@@ -5,5 +5,5 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
 
   :tools/deps [:system :home :project]
-  
-  :plugins [[lein-tools-deps "0.1.0-SNAPSHOT"]])
+
+  :plugins [[lein-tools-deps "0.3.0-SNAPSHOT"]])


### PR DESCRIPTION
This made `lein deps` / `lein repl` work for me in `example/`, where before I was getting an error.