### PR TITLE
Clarify required version of the CLI scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ You will need the following base dependencies installed:
 
 - Java 8 (recommended)
 - Leiningen 2.8.1
-- [Clojure 1.9.0+ CLI Tools](https://clojure.org/guides/getting_started)
+- [Clojure CLI Tools (1.9.0.341 or above)](https://clojure.org/guides/getting_started)
 
 ## Project Status
 


### PR DESCRIPTION
We depend on the existance of the -Sdescribe flag, which was introduced in
version 1.9.0.341 (released 2018-02-21) of the CLI scripts.