### PR TITLE
Search for clojure executable on PATH by default.

### DIFF
--- a/src/lein_tools_deps/env.clj
+++ b/src/lein_tools_deps/env.clj
@@ -11,15 +11,18 @@
 (defmethod exists? File [file]
   (.exists file))
 
-(def default-clojure-executables ["/usr/local/bin/clojure"])
-
-(defn- clojure-exe
+(defn clojure-exe
+  "Finds the best candidate name for the clojure command. If :clojure-executables
+   is mapped to a sequence of names to search, returns the first name that identifies
+   a valid file name. If no executables are provided, the clojure command will be
+   searched for on the PATH."
   [{:keys [clojure-executables]}]
-  (let [clojure-paths (or clojure-executables default-clojure-executables)
-        exe (->> clojure-paths
-                 (filter exists?)
-                 first)]
-    (or exe (throw (ex-info "Could not find clojure executable" {:tried-paths clojure-paths})))))
+  (if (seq clojure-executables)
+    (let [exe (->> clojure-executables
+                   (filter exists?)
+                   first)]
+      (or exe (throw (ex-info "Could not find clojure executable" {:tried-paths clojure-executables}))))
+    "clojure"))
 
 (defn- scrape-clojure-env
   [{:keys [root] config :lein-tools-deps/config}]

--- a/test/lein_tools_deps/env_test.clj
+++ b/test/lein_tools_deps/env_test.clj
@@ -1,0 +1,21 @@
+(ns lein-tools-deps.env-test
+  (:require [clojure.test :refer :all]
+            [lein-tools-deps.env :refer :all]))
+
+(deftest clojure-exe-test
+  (testing "Default"
+    (is (= "clojure" (clojure-exe {}))))
+
+  (testing "Valid executable specified"
+    (let [invalid "test/resources/missing"
+          valid "test/resources/clojure-cmd"]
+      (is (= valid (clojure-exe {:clojure-executables [invalid valid]})))))
+
+  (testing "No valid executable"
+    (let [candidates ["test/resources/bad-cmd"
+                      "test/resources/missing"]]
+      (try
+        (clojure-exe {:clojure-executables candidates})
+        (is false "Expected exception but none was thrown")
+        (catch Exception ex
+          (is (= {:tried-paths candidates} (ex-data ex))))))))


### PR DESCRIPTION
Issue #62 - Search for the clojure executable on the PATH if no
candidate clojure-executable items are specified in the project
configuration. If a sequence of executables is provided, at
least one must exist or an exception will be thrown.