### PR TITLE
[ Summary ] Fix a process fork issue on Windows

### DIFF
--- a/src/lein_tools_deps/env.clj
+++ b/src/lein_tools_deps/env.clj
@@ -29,7 +29,10 @@
   (shell/with-sh-dir
     root
     (let [exe (clojure-exe config)
-          {:keys [out exit] :as result} (shell/sh exe "-Sdescribe")]
+          {:keys [out exit] :as result}
+          (if (.startsWith (System/getProperty "os.name") "Windows")
+            (shell/sh "cmd" "/c" exe "-Sdescribe")
+            (shell/sh exe "-Sdescribe"))]
       (if (zero? exit)
         (read-string out)
         (throw (ex-info "Unable to locate Clojure's edn files" result))))))


### PR DESCRIPTION
[ Root Cause ]
1. There has no `clojure` script on Windows, the Clojure CLI is a PowerShell Module in windows, which cannot be called as a script directly.
2. Therefore, I make a `.bat` or `.cmd` to execute a PowerShell command.
3. After adding this `.bat` file to PATH, `lein-tools-deps` still cannot work, because the process created by `(shell/sh "clojure" "-Sdescribe")` cannot find either `clojure.bat` or `clojure.cmd` in PATH.

[Solution/Workaround ]
`(shell/sh "cmd" "/c" "clojure" "-Sdescribe")` work well for both the 'clojure' script file in PATH and custom path from `clojure-executables`.

[ Result ]
I test these two snippets in REPL:
(if (.startsWith (System/getProperty "os.name") "Windows")
  (shell/sh "cmd" "/c" "clojure" "-Sdescribe")
  (shell/sh "clojure" "-Sdescribe"))

(if (.startsWith (System/getProperty "os.name") "Windows")
  (shell/sh "cmd" "/c" "path/to/clojure.cmd" "-Sdescribe")
  (shell/sh "/path/to/clojure.cmd" "-Sdescribe"))